### PR TITLE
Use new FTS url

### DIFF
--- a/core/mysettings.py
+++ b/core/mysettings.py
@@ -55,7 +55,7 @@ class MySettings(SettingManager):
         # GeoMapFish settings
         self.addSetting("geomapfish", "bool", "project", True)
         self.addSetting("geomapfishUrl", "string", "project",
-                        'http://mapfish-geoportal.demo-camptocamp.com/demo/wsgi/fulltextsearch')
+                        'http://mapfish-geoportal.demo-camptocamp.com/1.5/search')
         self.addSetting("geomapfishCrs", "string", "project", 'EPSG:3857')
         self.addSetting("geomapfishUser", "string", "project", '')
         self.addSetting("geomapfishPass", "string", "project", '')


### PR DESCRIPTION
Since version 1.5 of GeoMapFish, the FTS is reachable with `search` instead of `wsgi/fulltextsearch`

See https://github.com/camptocamp/c2cgeoportal/blob/master/c2cgeoportal/scaffolds/create/apache/wsgi.conf.mako#L32