### PR TITLE
Use global settings

### DIFF
--- a/core/mysettings.py
+++ b/core/mysettings.py
@@ -34,9 +34,9 @@ class MySettings(SettingManager):
         SettingManager.__init__(self, pluginName)
 
         # general settings
-        self.addSetting("historyLength", "integer", "project", 3)
-        self.addSetting("categoryLimit", "integer", "project", 10)
-        self.addSetting("totalLimit", "integer", "project", 80)
+        self.addSetting("historyLength", "integer", "global", 3)
+        self.addSetting("categoryLimit", "integer", "global", 10)
+        self.addSetting("totalLimit", "integer", "global", 80)
 
         # project settings
         self.addSetting("project", "bool", "project", True)
@@ -48,14 +48,14 @@ class MySettings(SettingManager):
         self.addSetting("refreshLastAsked", "string", "project", "")
 
         # OpenStreetMap settings
-        self.addSetting("osm", "bool", "project", True)
-        self.addSetting("osmUrl", "string", "project",
+        self.addSetting("osm", "bool", "global", True)
+        self.addSetting("osmUrl", "string", "global",
                         'http://nominatim.openstreetmap.org/search')
 
         # GeoMapFish settings
-        self.addSetting("geomapfish", "bool", "project", True)
-        self.addSetting("geomapfishUrl", "string", "project",
+        self.addSetting("geomapfish", "bool", "global", True)
+        self.addSetting("geomapfishUrl", "string", "global",
                         'http://mapfish-geoportal.demo-camptocamp.com/1.5/search')
-        self.addSetting("geomapfishCrs", "string", "project", 'EPSG:3857')
-        self.addSetting("geomapfishUser", "string", "project", '')
-        self.addSetting("geomapfishPass", "string", "project", '')
+        self.addSetting("geomapfishCrs", "string", "global", 'EPSG:3857')
+        self.addSetting("geomapfishUser", "string", "global", '')
+        self.addSetting("geomapfishPass", "string", "global", '')

--- a/core/mysettings.py
+++ b/core/mysettings.py
@@ -39,7 +39,7 @@ class MySettings(SettingManager):
         self.addSetting("totalLimit", "integer", "global", 80)
 
         # project settings
-        self.addSetting("project", "bool", "project", True)
+        self.addSetting("project", "bool", "project", False)
         self.addSetting("layerId", "string", "project", '')
         self.addSetting("fieldName", "string", "project", '')
         self.addSetting("qftsfilepath", "string", "project", '')


### PR DESCRIPTION
The goal of this PR is to use global settings instead of project settings.

It's useful for the users that want to define only one time those settings and use them for all their projects.

Fix #27